### PR TITLE
Fix issue #5 - Custom Kotlin components not found in forms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.github.file5'
-version '1.0.2'
+version '1.0.3'
 
 pluginBundle {
     website = 'https://github.com/File5/intellij-idea-guidesigner-plugin'

--- a/src/main/groovy/io/github/file5/guidesigner/GuiDesignerModule.groovy
+++ b/src/main/groovy/io/github/file5/guidesigner/GuiDesignerModule.groovy
@@ -21,6 +21,7 @@ class GuiDesignerModule {
             formsClasspath.defaultDependencies {
                 it.add project.dependencies.create("com.jetbrains.intellij.java:java-compiler-ant-tasks:+")
                 it.add project.dependencies.create("com.jetbrains.intellij.java:java-gui-forms-rt:+")
+                it.add project.dependencies.create(project.sourceSets.main.runtimeClasspath)
             }
 
             def instrumentForms = project.task('instrumentForms') {


### PR DESCRIPTION
I add the `sourceSets.main.runtimeClasspath` to the classpath and raised the version number.

So, minimally reproductable example (MRE), provided in #5 is compiled ok. But as far as I understand, there are still some other problems. For example, MRE compiled and worked ok, but compiled with strange warning:

```
[ant:javac2] /home/chabapok/IdeaProjects/probas/form_design_try/app/src/main/java/form_design_try/FooForm.form: Class to bind does not exist: form_design_try.FooForm
```

Also, in my big project there are some other errors. I have the impression that something else is missing in the classpath.
I am not ready to localize the problem now. Perhaps later I will create another issue/MRE.
